### PR TITLE
引数なしコンストラクタ削除

### DIFF
--- a/src/DogApiNet/DogApiClient_Downtime.cs
+++ b/src/DogApiNet/DogApiClient_Downtime.cs
@@ -61,10 +61,6 @@ namespace DogApiNet
     [JsonFormatter(typeof(OptionalPropertySupportFormatter<DogDowntimeCreateParameter>))]
     public class DogDowntimeCreateParameter : DogDowntimeCreateUpateParameterBase<DogDowntimeCreateParameter>
     {
-        public DogDowntimeCreateParameter()
-        {                
-        }
-
         public DogDowntimeCreateParameter(params string[] scope)
         {
             Scope = scope;
@@ -76,10 +72,6 @@ namespace DogApiNet
     {
         [DataMember(Name = "id")]
         public long Id { get => GetValue<long>(); set => SetValue(value); }
-
-        public DogDowntimeUpdateParameter()
-        {                
-        }
 
         public DogDowntimeUpdateParameter(long id, params string[] scope)
         {
@@ -118,8 +110,8 @@ namespace DogApiNet
         [DataMember(Name = "until_occurrences")]
         public int? UntilOccurrences { get => GetValue<int?>(); set => SetValue(value); }
 
-        public DogDowntimeRecurrence()
-        {            
+        internal DogDowntimeRecurrence()
+        {
         }
 
         public DogDowntimeRecurrence(string type, int period)

--- a/src/DogApiNet/DogApiClient_Monitor.cs
+++ b/src/DogApiNet/DogApiClient_Monitor.cs
@@ -66,10 +66,6 @@ namespace DogApiNet
         [DataMember(Name = "options")]
         public DogMonitorOptions Options { get => GetValue<DogMonitorOptions>(); set => SetValue(value); }
 
-        public DogMonitorCreateParameter()
-        {
-        }
-
         public DogMonitorCreateParameter(string type, string query)
         {
             Type = type;
@@ -94,10 +90,6 @@ namespace DogApiNet
 
         [DataMember(Name = "options")]
         public DogMonitorOptions Options { get => GetValue<DogMonitorOptions>(); set => SetValue(value); }
-
-        public DogMonitorUpdateParameter()
-        {
-        }
 
         public DogMonitorUpdateParameter(string query)
         {

--- a/src/DogApiNet/JsonFormatters/OptionalPropertySupportFormatter.cs
+++ b/src/DogApiNet/JsonFormatters/OptionalPropertySupportFormatter.cs
@@ -8,7 +8,7 @@ using Utf8Json.Formatters;
 namespace DogApiNet.JsonFormatters
 {
     public sealed class OptionalPropertySupportFormatter<T> : IJsonFormatter<T> 
-        where T : OptionalPropertySupport<T>, new()
+        where T : OptionalPropertySupport<T>
     {
         public OptionalPropertySupportFormatter()
         {
@@ -24,7 +24,7 @@ namespace DogApiNet.JsonFormatters
             {
                 reader.ReadIsBeginObjectWithVerify();
 
-                var obj = new T();
+                var obj = (T)Activator.CreateInstance(typeof(T), true);
                 var propInfos = obj.OptionalPropertyInfosByJsonPropertyName;
                 var backingFields = obj.BackingFields;
                 var i = 0;


### PR DESCRIPTION
OptionalPropertySupportFormatter の new 制約を削除して、使わない引数なしコンストラクタを削除する。